### PR TITLE
Add cooldown configuration for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Introduce a cooldown period of 3 days for npm and GitHub Actions updates in the dependabot.yml configuration.